### PR TITLE
EE-5: Card Focus Mode

### DIFF
--- a/src/components/Canvas.css
+++ b/src/components/Canvas.css
@@ -128,3 +128,100 @@
 .page-title-input:focus {
   border-bottom-color: #4a9eff;
 }
+
+.canvas-focus-mode {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.focus-toolbar {
+    display: flex;
+    align-items: center;
+    padding: 10px 20px;
+    border-bottom: 1px solid #2a2a2a;
+    background: #161616;
+    flex-shrink: 0;
+    gap: 16px;
+}
+
+.focus-exit-btn {
+    background: none;
+    border: 1px solid #333;
+    border-radius: 5px;
+    color: #aaa;
+    font-size: 12px;
+    padding: 4px 12px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.focus-exit-btn:hover {
+    background: #2a2a2a;
+    color: #e0e0e0;
+    border-color: #555;
+}
+
+.focus-breadcrumb {
+    flex: 1;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 500;
+    color: #888;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.focus-export-btn {
+    background: none;
+    border: 1px solid #333;
+    border-radius: 5px;
+    color: #aaa;
+    font-size: 12px;
+    padding: 4px 12px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.focus-export-btn:hover {
+    background: #2a2a2a;
+    color: #e0e0e0;
+    border-color: #555;
+}
+
+.focus-card-body {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.focus-editor-wrap {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.focus-editor-wrap .cm-editor {
+    height: 100%;
+}
+
+.focus-editor-wrap .cm-scroller {
+    overflow: auto;
+}
+
+.focus-note-editor {
+    flex: 1;
+    width: 100%;
+    background: #181818;
+    border: none;
+    color: #d4d4d4;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 14px;
+    line-height: 1.7;
+    padding: 24px 32px;
+    resize: none;
+    outline: none;
+}

--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { usePage } from '../hooks/usePage.js'
 import { useVim } from '../hooks/useVim.js'
+import CodeEditor from './CodeEditor.jsx'
 import Lane from './Lane.jsx'
 import FindBar from './FindBar.jsx'
 import {
@@ -46,6 +47,11 @@ export default function Canvas({ folder, fileName, onSaveReady, onRefresh, onFil
 function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, onFileRenamed }) {
     const [dirty, setDirty] = useState(false)
     const [activeCard, setActiveCard] = useState(null)
+    const [focusMode, setFocusMode] = useState(false)
+    const [focusedCardData, setFocusedCardData] = useState(null)
+    const [focusedLaneData, setFocusedLaneData] = useState(null)
+    const [focusModeLaneId, setFocusModeLaneId] = useState(null)
+    const [focusModeCardId, setFocusModeCardId] = useState(null)
 
     // ── Find state ───────────────────────────────────────────────
     const [findOpen, setFindOpen] = useState(false)
@@ -58,7 +64,7 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
         addCard, updateCard, deleteCard, reorderCards, moveCard,
     } = usePage(initialData)
 
-    // ── Compute find matches ─────────────────────────────────────
+    // ── Find matches ─────────────────────────────────────────────
     const findMatches = []
     if (findQuery.trim()) {
         const q = findQuery.toLowerCase()
@@ -98,7 +104,6 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
         setFindMatchIndex(i => (i - 1 + findMatches.length) % findMatches.length)
     }
 
-    // Reset match index when query changes
     useEffect(() => {
         setFindMatchIndex(0)
     }, [findQuery])
@@ -127,6 +132,17 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
         onSave: () => save(),
         onNewPage: () => {},
         onOpenFind: openFind,
+        onToggleFocusMode: (val) => {
+            setFocusMode(val)
+            if (val) {
+                const card = getFocusedCard()
+                const lane = getFocusedLane()
+                setFocusedCardData(card)
+                setFocusedLaneData(lane)
+                setFocusModeLaneId(lane?.id ?? null)
+                setFocusModeCardId(card?.id ?? null)
+            }
+        },
     })
 
     // ── Dirty tracking ───────────────────────────────────────────
@@ -139,7 +155,7 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
         setDirty(true)
     }, [page])
 
-    // ── Save ────────────────────────────────────────────
+    // ── Save ─────────────────────────────────────────────────────
     async function save() {
         await window.lanepad.writePage(folder, fileName, page)
         setDirty(false)
@@ -149,6 +165,72 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
     useEffect(() => {
         if (onSaveReady) onSaveReady(save)
     }, [page])
+
+    // ── Card export helpers ───────────────────────────────────────
+    function exportCardJson(card) {
+        const exportData = {
+            title: card.title,
+            type: card.type,
+            content: card.content,
+            language: card.language,
+            color: card.color,
+        }
+        const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${card.title.toLowerCase().replace(/\s+/g, '-')}.json`
+        a.click()
+        URL.revokeObjectURL(url)
+    }
+
+    function exportLaneJson(lane) {
+        const exportData = {
+            name: lane.name,
+            cards: lane.cards.map(c => ({
+                title: c.title,
+                type: c.type,
+                content: c.content,
+                language: c.language,
+                color: c.color,
+            })),
+        }
+        const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${lane.name.toLowerCase().replace(/\s+/g, '-')}-lane.json`
+        a.click()
+        URL.revokeObjectURL(url)
+    }
+
+    function importCardsJson(laneId) {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = '.json'
+        input.onchange = async (e) => {
+            const file = e.target.files[0]
+            if (!file) return
+            const text = await file.text()
+            try {
+                const data = JSON.parse(text)
+                const { nanoid } = await import('nanoid')
+                // Single card or lane export
+                if (data.cards) {
+                    // Lane export — import all cards
+                    for (const card of data.cards) {
+                        addCard(laneId, null, { ...card, id: nanoid() })
+                    }
+                } else if (data.title) {
+                    // Single card export
+                    addCard(laneId, null, { ...data, id: nanoid() })
+                }
+            } catch {
+                console.error('Invalid JSON file')
+            }
+        }
+        input.click()
+    }
 
     // ── Drag and drop ────────────────────────────────────────────
     const sensors = useSensors(
@@ -218,6 +300,65 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
 
     const laneIds = page.lanes.map(l => l.id)
     const focusedCard = getFocusedCard()
+    const focusedLane = getFocusedLane()
+
+    // ── Focus mode render ────────────────────────────────────────
+    if (focusMode && focusModeCardId) {
+        const liveLane = page.lanes.find(l => l.id === focusModeLaneId)
+        const liveCard = liveLane?.cards.find(c => c.id === focusModeCardId) ?? focusedCardData
+
+        return (
+            <div className="canvas-root canvas-focus-mode">
+                <div className="focus-toolbar">
+                    <button
+                        className="focus-exit-btn"
+                        onClick={() => setFocusMode(false)}
+                    >
+                        ← Exit Focus
+                    </button>
+                    <span className="focus-breadcrumb">
+                        {liveLane?.name ?? ''}
+                        {liveLane?.name ? ' › ' : ''}
+                        {liveCard.title}
+                    </span>
+                    <button
+                        className="focus-export-btn"
+                        onClick={() => exportCardJson(liveCard)}
+                    >
+                        Export Card JSON
+                    </button>
+                </div>
+                <div className="focus-card-body">
+                    {liveCard.type === 'code' && (
+                        <div className="focus-editor-wrap">
+                            <CodeEditor
+                                value={liveCard.content}
+                                language={liveCard.language}
+                                onChange={(val) => {
+                                    if (focusModeLaneId) {
+                                        updateCard(focusModeLaneId, focusModeCardId, { content: val })
+                                    }
+                                }}
+                                onEscape={() => document.activeElement?.blur()}
+                            />
+                        </div>
+                    )}
+                    {liveCard.type === 'note' && (
+                        <textarea
+                            className="focus-note-editor"
+                            value={liveCard.content}
+                            onChange={e => {
+                                if (focusModeLaneId) {
+                                    updateCard(focusModeLaneId, focusModeCardId, { content: e.target.value })
+                                }
+                            }}
+                            placeholder="Write a note..."
+                        />
+                    )}
+                </div>
+            </div>
+        )
+    }
 
     return (
         <div className={`canvas-root direction-${page.direction}`}>
@@ -228,7 +369,6 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
                     onChange={e => setTitle(e.target.value)}
                     placeholder="Page title"
                 />
-                {dirty && <span className="dirty-indicator">Unsaved changes</span>}
                 <div className="direction-toggle">
                     <button
                         className={page.direction === 'horizontal' ? 'active' : ''}
@@ -241,6 +381,7 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
                         title="Vertical lanes (columns)"
                     >⇅ Columns</button>
                 </div>
+                {dirty && <span className="dirty-indicator">Unsaved changes</span>}
             </div>
 
             {findOpen && (
@@ -289,6 +430,9 @@ function CanvasInner({ folder, fileName, initialData, onSaveReady, onRefresh, on
                                     const cardIndex = lane.cards.findIndex(c => c.id === cardId)
                                     setCursor({ laneIndex, cardIndex })
                                 }}
+                                onExportCard={exportCardJson}
+                                onExportLane={() => exportLaneJson(lane)}
+                                onImportCards={() => importCardsJson(lane.id)}
                             />
                         ))}
                         <button className="add-lane-btn" onClick={addLane}>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import * as ContextMenu from '@radix-ui/react-context-menu'
 import './Card.css'
 import CodeEditor from './CodeEditor.jsx'
 
@@ -18,7 +19,7 @@ const LANGUAGES = [
     'json', 'bash', 'html', 'css', 'other'
 ]
 
-export default function Card({ card, onUpdate, onDelete, dragHandleProps = {}, isFocused, isMatch, isCurrentMatch }) {
+export default function Card({ card, onUpdate, onDelete, dragHandleProps = {}, isFocused, isMatch, isCurrentMatch, onExportCard }) {
     const [editingTitle, setEditingTitle] = useState(false)
     const [titleValue, setTitleValue] = useState(card.title)
     const [showColorPicker, setShowColorPicker] = useState(false)
@@ -49,160 +50,188 @@ export default function Card({ card, onUpdate, onDelete, dragHandleProps = {}, i
 
     if (card.type === 'heading') {
         return (
-            <div
-                className={`card card-heading ${isFocused ? 'vim-focused' : ''} ${isCurrentMatch ? 'find-current' : isMatch ? 'find-match' : ''}`}
-                data-card-id={card.id}
-            >
-                <button className="card-drag-handle" {...dragHandleProps} title="Drag to reorder">⠿</button>
-                {editingTitle ? (
-                    <input
-                        className="card-heading-input"
-                        value={titleValue}
-                        autoFocus
-                        onChange={e => setTitleValue(e.target.value)}
-                        onBlur={commitTitle}
-                        onKeyDown={e => {
-                            if (e.key === 'Enter') commitTitle()
-                            if (e.key === 'Escape') { setTitleValue(card.title); setEditingTitle(false) }
-                        }}
-                    />
-                ) : (
-                    <span
-                        className="card-heading-label"
-                        onDoubleClick={() => setEditingTitle(true)}
-                    >{card.title}</span>
-                )}
-                <button className="card-delete-btn" onClick={onDelete}>✕</button>
-            </div>
+            <ContextMenu.Root>
+                <ContextMenu.Trigger asChild>
+                    <div
+                        className={`card card-heading ${isFocused ? 'vim-focused' : ''} ${isCurrentMatch ? 'find-current' : isMatch ? 'find-match' : ''}`}
+                        data-card-id={card.id}
+                    >
+                        <button className="card-drag-handle" {...dragHandleProps} title="Drag to reorder">⠿</button>
+                        {editingTitle ? (
+                            <input
+                                className="card-heading-input"
+                                value={titleValue}
+                                autoFocus
+                                onChange={e => setTitleValue(e.target.value)}
+                                onBlur={commitTitle}
+                                onKeyDown={e => {
+                                    if (e.key === 'Enter') commitTitle()
+                                    if (e.key === 'Escape') { setTitleValue(card.title); setEditingTitle(false) }
+                                }}
+                            />
+                        ) : (
+                            <span
+                                className="card-heading-label"
+                                onDoubleClick={() => setEditingTitle(true)}
+                            >{card.title}</span>
+                        )}
+                        <button className="card-delete-btn" onClick={onDelete}>✕</button>
+                    </div>
+                </ContextMenu.Trigger>
+            <ContextMenu.Portal>
+                <ContextMenu.Content className="context-menu">
+                    <ContextMenu.Item 
+                        className="context-menu-item" 
+                        onSelect={() => onExportCard(card)}
+                    >
+                        Export Card as JSON
+                    </ContextMenu.Item>
+                </ContextMenu.Content>
+            </ContextMenu.Portal>
+        </ContextMenu.Root>
         )
     }
 
     return (
-        <div
-            className={`card ${card.collapsed ? 'collapsed' : ''} ${isFocused ? 'vim-focused' : ''} ${isCurrentMatch ? 'find-current' : isMatch ? 'find-match' : ''}`}
-            data-card-id={card.id}
-        >
-            <div
-                className="card-header"
-                style={accentColor ? { background: accentColor } : {}}
-            >
-                <button
-                    className="card-drag-handle"
-                    {...dragHandleProps}
-                    title="Drag to reorder"
-                >⠿</button>
-
-                <button
-                    className="card-collapse-btn"
-                    onClick={() => onUpdate({ collapsed: !card.collapsed })}
-                    title={card.collapsed ? 'Expand' : 'Collapse'}
+        <ContextMenu.Root>
+            <ContextMenu.Trigger asChild>
+                <div
+                    className={`card ${card.collapsed ? 'collapsed' : ''} ${isFocused ? 'vim-focused' : ''} ${isCurrentMatch ? 'find-current' : isMatch ? 'find-match' : ''}`}
+                    data-card-id={card.id}
                 >
-                    {card.collapsed ? '▶' : '▼'}
-                </button>
-
-                {editingTitle ? (
-                    <input
-                        className="card-title-input"
-                        value={titleValue}
-                        autoFocus
-                        onChange={e => setTitleValue(e.target.value)}
-                        onBlur={commitTitle}
-                        onKeyDown={e => {
-                            if (e.key === 'Enter') commitTitle()
-                            if (e.key === 'Escape') { setTitleValue(card.title); setEditingTitle(false) }
-                        }}
-                    />
-                ) : (
-                    <span
-                        className="card-title"
-                        onDoubleClick={() => setEditingTitle(true)}
-                        title="Double-click to rename"
-                    >{card.title}</span>
-                )}
-
-                <div className="card-header-meta">
-                    {card.type === 'code' && !card.collapsed && (
-                        <select
-                            className="card-language-select"
-                            value={card.language}
-                            onChange={e => onUpdate({ language: e.target.value })}
-                            onClick={e => e.stopPropagation()}
-                        >
-                            {LANGUAGES.map(l => (
-                                <option key={l} value={l}>{l}</option>
-                            ))}
-                        </select>
-                    )}
-
-                    <select
-                        className="card-type-select"
-                        value={card.type}
-                        onChange={e => onUpdate({ type: e.target.value })}
-                        onClick={e => e.stopPropagation()}
-                        title="Card type"
+                    <div
+                        className="card-header"
+                        style={accentColor ? { background: accentColor } : {}}
                     >
-                        <option value="code">code</option>
-                        <option value="note">note</option>
-                    </select>
-
-                    <div className="card-color-picker-wrap" ref={colorPickerRef}>
                         <button
-                            className="card-color-btn"
-                            style={accentColor ? { background: accentColor } : {}}
-                            onClick={() => setShowColorPicker(v => !v)}
-                            title="Set color"
+                            className="card-drag-handle"
+                            {...dragHandleProps}
+                            title="Drag to reorder"
+                        >⠿</button>
+
+                        <button
+                            className="card-collapse-btn"
+                            onClick={() => onUpdate({ collapsed: !card.collapsed })}
+                            title={card.collapsed ? 'Expand' : 'Collapse'}
                         >
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 2C9 7 5 11 5 15a7 7 0 0 0 14 0c0-4-4-8-7-13z"/>
-                            </svg>
+                            {card.collapsed ? '▶' : '▼'}
                         </button>
-                        {showColorPicker && (
-                            <div className="card-color-dropdown">
-                                {COLORS.map(c => (
-                                    <button
-                                        key={c.id}
-                                        className={`color-swatch ${card.color === c.value ? 'active' : ''}`}
-                                        style={{ background: c.value ?? '#2a2a2a' }}
-                                        title={c.label}
-                                        onClick={() => {
-                                            onUpdate({ color: c.value })
-                                            setShowColorPicker(false)
-                                        }}
-                                    />
-                                ))}
-                            </div>
+
+                        {editingTitle ? (
+                            <input
+                                className="card-title-input"
+                                value={titleValue}
+                                autoFocus
+                                onChange={e => setTitleValue(e.target.value)}
+                                onBlur={commitTitle}
+                                onKeyDown={e => {
+                                    if (e.key === 'Enter') commitTitle()
+                                    if (e.key === 'Escape') { setTitleValue(card.title); setEditingTitle(false) }
+                                }}
+                            />
+                        ) : (
+                            <span
+                                className="card-title"
+                                onDoubleClick={() => setEditingTitle(true)}
+                                title="Double-click to rename"
+                            >{card.title}</span>
                         )}
+
+                        <div className="card-header-meta">
+                            {card.type === 'code' && !card.collapsed && (
+                                <select
+                                    className="card-language-select"
+                                    value={card.language}
+                                    onChange={e => onUpdate({ language: e.target.value })}
+                                    onClick={e => e.stopPropagation()}
+                                >
+                                    {LANGUAGES.map(l => (
+                                        <option key={l} value={l}>{l}</option>
+                                    ))}
+                                </select>
+                            )}
+
+                            <select
+                                className="card-type-select"
+                                value={card.type}
+                                onChange={e => onUpdate({ type: e.target.value })}
+                                onClick={e => e.stopPropagation()}
+                                title="Card type"
+                            >
+                                <option value="code">code</option>
+                                <option value="note">note</option>
+                            </select>
+
+                            <div className="card-color-picker-wrap" ref={colorPickerRef}>
+                                <button
+                                    className="card-color-btn"
+                                    style={accentColor ? { background: accentColor } : {}}
+                                    onClick={() => setShowColorPicker(v => !v)}
+                                    title="Set color"
+                                >
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M12 2C9 7 5 11 5 15a7 7 0 0 0 14 0c0-4-4-8-7-13z"/>
+                                    </svg>
+                                </button>
+                                {showColorPicker && (
+                                    <div className="card-color-dropdown">
+                                        {COLORS.map(c => (
+                                            <button
+                                                key={c.id}
+                                                className={`color-swatch ${card.color === c.value ? 'active' : ''}`}
+                                                style={{ background: c.value ?? '#2a2a2a' }}
+                                                title={c.label}
+                                                onClick={() => {
+                                                    onUpdate({ color: c.value })
+                                                    setShowColorPicker(false)
+                                                }}
+                                            />
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+
+                            <button
+                                className="card-delete-btn"
+                                onClick={onDelete}
+                                title="Delete card"
+                            >✕</button>
+                        </div>
                     </div>
 
-                    <button
-                        className="card-delete-btn"
-                        onClick={onDelete}
-                        title="Delete card"
-                    >✕</button>
-                </div>
-            </div>
-
-            {!card.collapsed && (
-                <div className="card-body">
-                    {card.type === 'code' && (
-                        <CodeEditor
-                            value={card.content}
-                            language={card.language}
-                            onChange={(val) => onUpdate({ content: val })}
-                            onEscape={() => document.activeElement?.blur()}
-                        />
-                    )}
-                    {card.type === 'note' && (
-                        <textarea
-                            className="card-note-editor"
-                            value={card.content}
-                            onChange={e => onUpdate({ content: e.target.value })}
-                            placeholder="Write a note..."
-                            rows={4}
-                        />
+                    {!card.collapsed && (
+                        <div className="card-body">
+                            {card.type === 'code' && (
+                                <CodeEditor
+                                    value={card.content}
+                                    language={card.language}
+                                    onChange={(val) => onUpdate({ content: val })}
+                                    onEscape={() => document.activeElement?.blur()}
+                                />
+                            )}
+                            {card.type === 'note' && (
+                                <textarea
+                                    className="card-note-editor"
+                                    value={card.content}
+                                    onChange={e => onUpdate({ content: e.target.value })}
+                                    placeholder="Write a note..."
+                                    rows={4}
+                                />
+                            )}
+                        </div>
                     )}
                 </div>
-            )}
-        </div>
+            </ContextMenu.Trigger>
+            <ContextMenu.Portal>
+                <ContextMenu.Content className="context-menu">
+                    <ContextMenu.Item 
+                        className="context-menu-item" 
+                        onSelect={() => onExportCard(card)}
+                    >
+                        Export Card as JSON
+                    </ContextMenu.Item>
+                </ContextMenu.Content>
+            </ContextMenu.Portal>
+        </ContextMenu.Root>
     )
 }

--- a/src/components/Lane.jsx
+++ b/src/components/Lane.jsx
@@ -13,6 +13,9 @@ export default function Lane({
     isLaneFocused,
     findMatchCardId,
     findMatchCardIds,
+    onExportCard,
+    onExportLane,
+    onImportCard,
 }) {
     const [editingName, setEditingName] = useState(false)
     const [nameValue, setNameValue] = useState(lane.name)
@@ -106,10 +109,17 @@ export default function Lane({
                                     <button onClick={() => handleAddCard('code')}>Code</button>
                                     <button onClick={() => handleAddCard('note')}>Note</button>
                                     <button onClick={() => handleAddCard('heading')}>Heading</button>
+                                    <hr style={{ border: 'none', borderTop: '1px solid #333', margin: '4px 0' }} />
+                                    <button onClick={() => { onImportCards(); setAddingType(false) }}>Import JSON</button>
                                 </div>
                             )}
                         </div>
                     )}
+                    <button
+                        className="lane-action-btn"
+                        onClick={onExportLane}
+                        title="Export lane as JSON"
+                    >↓</button>
                     <button
                         className="lane-action-btn danger"
                         onClick={onDeleteLane}
@@ -136,6 +146,7 @@ export default function Lane({
                                 onUpdate={(changes) => onUpdateCard(card.id, changes)}
                                 onDelete={() => onDeleteCard(card.id)}
                                 onClick={() => onCardClick(card.id)}
+                                onExportCard={() => onExportCard(card)}
                             />
                         ))}
                     </DroppableLaneBody>
@@ -157,7 +168,7 @@ function DroppableLaneBody({ laneId, children }) {
     )
 }
 
-function SortableCard({ card, onUpdate, onDelete, onClick, isFocused, isMatch, isCurrentMatch }) {
+function SortableCard({ card, onUpdate, onDelete, onClick, isFocused, isMatch, isCurrentMatch, onExportCard }) {
     const {
         attributes,
         listeners,
@@ -182,6 +193,7 @@ function SortableCard({ card, onUpdate, onDelete, onClick, isFocused, isMatch, i
                 isCurrentMatch={isCurrentMatch}
                 onUpdate={onUpdate}
                 onDelete={onDelete}
+                onExportCard={onExportCard}
                 dragHandleProps={{ ...attributes, ...listeners }}
             />
         </div>

--- a/src/components/StatusBar.css
+++ b/src/components/StatusBar.css
@@ -46,3 +46,7 @@
 .mode-none {
     color: #444;
 }
+
+.mode-focus {
+    color: #cca5f3;
+}

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -3,22 +3,22 @@ import './StatusBar.css'
 
 export default function StatusBar() {
     const { vimState } = useVimContext()
-    const { cursor, insertMode, pendingDelete, pendingLaneDelete, laneDeleteBlocked, yanked, page } = vimState
+    const {
+        cursor, insertMode, pendingDelete, pendingLaneDelete,
+        laneDeleteBlocked, yanked, page, focusMode
+    } = vimState
 
     const isDefocused = cursor.laneIndex === null
 
-    // ── Left: location ────────────────────────────────────────────
     function getLocation() {
         if (!page || isDefocused) return '—'
         const lane = page.lanes[cursor.laneIndex]
         if (!lane) return '—'
         const laneCount = page.lanes.length
         const lanePos = `lane ${cursor.laneIndex + 1}/${laneCount}`
-
         if (cursor.cardIndex === null) {
             return `${lane.name}  [${lanePos}]`
         }
-
         const card = lane.cards[cursor.cardIndex]
         if (!card) return `${lane.name}  [${lanePos}]`
         const cardCount = lane.cards.length
@@ -26,7 +26,6 @@ export default function StatusBar() {
         return `${lane.name}  ›  ${card.title}  [${lanePos} · ${cardPos}]`
     }
 
-    // ── Middle: hints ─────────────────────────────────────────────
     function getHint() {
         if (laneDeleteBlocked) return 'remove all cards before deleting lane'
         if (pendingLaneDelete) return 'press Shift+X again to confirm lane delete'
@@ -35,8 +34,8 @@ export default function StatusBar() {
         return ''
     }
 
-    // ── Right: mode ───────────────────────────────────────────────
     function getMode() {
+        if (focusMode) return { label: 'FOCUS', cls: 'mode-focus' }
         if (isDefocused) return { label: '-- --', cls: 'mode-none' }
         if (insertMode) return { label: 'INSERT', cls: 'mode-insert' }
         return { label: 'NORMAL', cls: 'mode-normal' }

--- a/src/context/VimContext.jsx
+++ b/src/context/VimContext.jsx
@@ -11,6 +11,7 @@ export function VimProvider({ children }) {
         laneDeleteBlocked: false,
         yanked: null,
         page: null,
+        focusMode: false,
     })
 
     return (

--- a/src/hooks/useVim.js
+++ b/src/hooks/useVim.js
@@ -13,6 +13,7 @@ export function useVim({
     onSave,
     onNewPage,
     onOpenFind,
+    onToggleFocusMode,
 }) {
     const [cursor, setCursorRaw] = useState({ laneIndex: 0, cardIndex: null })
     const [yanked, setYankedRaw] = useState(null)
@@ -21,6 +22,7 @@ export function useVim({
     const [pendingLaneDelete, setPendingLaneDelete] = useState(false)
     const [laneDeleteBlocked, setLaneDeleteBlocked] = useState(false)
     const [insertMode, setInsertMode] = useState(false)
+    const [focusMode, setFocusModeRaw] = useState(false)
 
     const gTimer = useRef(null)
     const deleteTimer = useRef(null)
@@ -29,7 +31,6 @@ export function useVim({
 
     const { setVimState } = useVimContext()
 
-    // Sync all vim state to context whenever anything changes
     useEffect(() => {
         setVimState({
             cursor,
@@ -39,19 +40,18 @@ export function useVim({
             laneDeleteBlocked,
             yanked,
             page,
+            focusMode,
         })
-    }, [cursor, insertMode, pendingDelete, pendingLaneDelete, laneDeleteBlocked, yanked, page])
+    }, [cursor, insertMode, pendingDelete, pendingLaneDelete, laneDeleteBlocked, yanked, page, focusMode])
 
-    // Wrap setCursor to keep things clean
-    const setCursor = useCallback((val) => {
-        setCursorRaw(val)
-    }, [])
+    const setCursor = useCallback((val) => setCursorRaw(val), [])
+    const setYanked = useCallback((val) => setYankedRaw(val), [])
 
-    const setYanked = useCallback((val) => {
-        setYankedRaw(val)
-    }, [])
+    const setFocusMode = useCallback((val) => {
+        setFocusModeRaw(val)
+        if (onToggleFocusMode) onToggleFocusMode(val)
+    }, [onToggleFocusMode])
 
-    // Track insert mode via focus/blur events
     useEffect(() => {
         function onFocus() {
             const active = document.activeElement
@@ -109,28 +109,18 @@ export function useVim({
         const lanes = page.lanes
 
         function handleKeyDown(e) {
-            // Always-on shortcuts
             if ((e.metaKey || e.ctrlKey) && e.key === 's') {
                 e.preventDefault()
                 onSave?.()
                 return
             }
 
-            // if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
-            //     e.preventDefault()
-            //     onNewPage?.()
-            //     return
-            // }
-
-            if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
-                e.preventDefault()
-                onOpenFind?.()
-                return
-            }
-
             if (e.key === 'Escape') {
+                if (focusMode) {
+                    setFocusMode(false)
+                    return
+                }
                 if (!isInsertMode()) {
-                    // Second escape — clear cursor entirely
                     setCursor({ laneIndex: null, cardIndex: null })
                 } else {
                     document.activeElement?.blur()
@@ -140,7 +130,6 @@ export function useVim({
 
             if (isInsertMode()) return
 
-            // Re-enter at lane 0 if cursor is fully cleared
             if (cursor.laneIndex === null) {
                 if (['h', 'j', 'k', 'l', 'g', 'G', 'n', 'y', 'p', ' '].includes(e.key)) {
                     setCursor({ laneIndex: 0, cardIndex: null })
@@ -152,6 +141,16 @@ export function useVim({
 
             const { laneIndex, cardIndex } = cursor
             const currentLane = lanes[laneIndex]
+
+            // ── z — toggle focus mode ─────────────────────────────
+            if (e.key === 'z') {
+                e.preventDefault()
+                const focusedCard = getFocusedCard()
+                if (focusedCard) {
+                    setFocusMode(!focusMode)
+                }
+                return
+            }
 
             // ── g g sequence ──────────────────────────────────────
             if (e.key === 'g' && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
@@ -258,12 +257,10 @@ export function useVim({
             if (e.key === 'Enter' && e.shiftKey) {
                 e.preventDefault()
                 if (cardIndex === null) {
-                    // Lane level — rename lane
                     const laneEl = document.querySelector(`[data-lane-id="${currentLane?.id}"]`)
                     const nameEl = laneEl?.querySelector('.lane-name')
                     if (nameEl) nameEl.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
                 } else {
-                    // Card level — rename card title
                     const focusedCard = getFocusedCard()
                     if (!focusedCard) return
                     const cardEl = document.querySelector(`[data-card-id="${focusedCard.id}"]`)
@@ -374,11 +371,18 @@ export function useVim({
                 }
                 return
             }
+
+            // ── Cmd+F — find ──────────────────────────────────────
+            if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+                e.preventDefault()
+                onOpenFind?.()
+                return
+            }
         }
 
         window.addEventListener('keydown', handleKeyDown)
         return () => window.removeEventListener('keydown', handleKeyDown)
-    }, [page, cursor, pendingG, pendingDelete, pendingLaneDelete, yanked, isInsertMode])
+    }, [page, cursor, pendingG, pendingDelete, pendingLaneDelete, yanked, focusMode, isInsertMode])
 
     return {
         cursor,
@@ -388,6 +392,8 @@ export function useVim({
         pendingLaneDelete,
         laneDeleteBlocked,
         insertMode,
+        focusMode,
+        setFocusMode,
         getFocusedCard,
         getFocusedLane,
     }


### PR DESCRIPTION
## Summary
Introduces a `focusMode` to the Vim navigation, allowing users to temporarily concentrate on a single card. This feature is activated by the 'z' key when a card is selected and can be toggled off with 'Escape' or 'z' again. The `StatusBar` component now reflects the active mode, and the `useVim` hook has been updated to manage and expose the `focusMode` state.

### ✨ New Feature
- **`StatusBar`** — displays 'FOCUS' mode when `focusMode` is active
- **`useVim.js`** — implements `focusMode` state, toggle logic with 'z' key, and integration with `StatusBar`

##
